### PR TITLE
Use reference to unknown node in `formatError` helper

### DIFF
--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -20,16 +20,16 @@ export class ChainNodeParser implements SubNodeParser {
         return this.nodeParsers.some((nodeParser: SubNodeParser) => nodeParser.supportsNode(node));
     }
     public createType(node: ts.Node, context: Context): BaseType {
-        return this.getNodeParser(node).createType(node, context);
+        return this.getNodeParser(node, context).createType(node, context);
     }
 
-    private getNodeParser(node: ts.Node): SubNodeParser {
+    private getNodeParser(node: ts.Node, context: Context): SubNodeParser {
         for (const nodeParser of this.nodeParsers) {
             if (nodeParser.supportsNode(node)) {
                 return nodeParser;
             }
         }
 
-        throw new UnknownNodeError(node);
+        throw new UnknownNodeError(node, context.getReference());
     }
 }

--- a/src/Error/UnknownNodeError.ts
+++ b/src/Error/UnknownNodeError.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 import { BaseError } from "./BaseError";
 
 export class UnknownNodeError extends BaseError {
-    public constructor(private node: ts.Node) {
+    public constructor(private node: ts.Node, private reference: ts.Node) {
         super();
     }
 
@@ -15,5 +15,8 @@ export class UnknownNodeError extends BaseError {
 
     public getNode(): ts.Node {
         return this.node;
+    }
+    public getReference(): ts.Node {
+        return this.reference;
     }
 }

--- a/src/NodeParser.ts
+++ b/src/NodeParser.ts
@@ -4,6 +4,11 @@ import { BaseType } from "./Type/BaseType";
 export class Context {
     private arguments: BaseType[] = [];
     private parameters: string[] = [];
+    private reference: ts.Node;
+
+    public constructor(reference?: ts.Node) {
+        this.reference = reference;
+    }
 
     public pushArgument(argumentType: BaseType): void {
         this.arguments.push(argumentType);
@@ -22,6 +27,10 @@ export class Context {
     }
     public getArguments(): BaseType[] {
         return this.arguments;
+    }
+
+    public getReference(): ts.Node {
+        return this.reference;
     }
 }
 

--- a/src/NodeParser/ExpressionWithTypeArgumentsNodeParser.ts
+++ b/src/NodeParser/ExpressionWithTypeArgumentsNodeParser.ts
@@ -32,7 +32,7 @@ export class ExpressionWithTypeArgumentsNodeParser implements SubNodeParser {
     }
 
     private createSubContext(node: ts.ExpressionWithTypeArguments, parentContext: Context): Context {
-        const subContext: Context = new Context();
+        const subContext: Context = new Context(node);
         if (node.typeArguments && node.typeArguments.length) {
             node.typeArguments.forEach((typeArg: ts.TypeNode) => {
                 subContext.pushArgument(this.childNodeParser.createType(typeArg, parentContext));

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -35,7 +35,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
     }
 
     private createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {
-        const subContext: Context = new Context();
+        const subContext: Context = new Context(node);
         if (node.typeArguments && node.typeArguments.length) {
             node.typeArguments.forEach((typeArg: ts.TypeNode) => {
                 subContext.pushArgument(this.childNodeParser.createType(typeArg, parentContext));

--- a/src/Utils/formatError.ts
+++ b/src/Utils/formatError.ts
@@ -36,9 +36,10 @@ export function formatError(error: BaseError): string {
             getNewLine: () => "\n",
         });
     } else if (error instanceof UnknownNodeError) {
-        const firstLine: string = error.getNode().getFullText().trim().split("\n")[0].trim();
-        const [sourceFile, lineNumber, charPos]: [string, number, number] = getNodeLocation(error.getNode());
-        return `${error.name}: Unknown node type "${firstLine}" at ${sourceFile}(${lineNumber},${charPos})\n`;
+        const unknownNode: ts.Node = error.getReference() || error.getNode();
+        const nodeFullText: string = unknownNode.getFullText().trim().split("\n")[0].trim();
+        const [sourceFile, lineNumber, charPos]: [string, number, number] = getNodeLocation(unknownNode);
+        return `${error.name}: Unknown node "${nodeFullText}" at ${sourceFile}(${lineNumber},${charPos})\n`;
     }
 
     return `${error.name}: ${error.message}\n`;


### PR DESCRIPTION
Issue #1.

Now `UnknownNodeError` is formatted like this:

```
UnknownNodeError: Unknown node "typeof TypeOf" at /tmp/playground.ts(4,13)
```

for this code:
```ts
const TypeOf = "some value";

export interface MyObject {
    unknown: typeof TypeOf;
}
```

@domoritz Is this informative enough?